### PR TITLE
fix PHP 8.2 deprecated string interpolation

### DIFF
--- a/lib/Rudder.php
+++ b/lib/Rudder.php
@@ -160,7 +160,7 @@ private static function handleUrl($data_plane_url, $protocol) {
   public static function validate($msg, $type){
     $userId = !empty($msg["userId"]);
     $anonId = !empty($msg["anonymousId"]);
-    self::assert($userId || $anonId, "Rudder::${type}() requires userId or anonymousId");
+    self::assert($userId || $anonId, "Rudder::{$type}() requires userId or anonymousId");
   }
 
   /**

--- a/lib/Rudder/Consumer/ForkCurl.php
+++ b/lib/Rudder/Consumer/ForkCurl.php
@@ -42,7 +42,7 @@ class Rudder_Consumer_ForkCurl extends Rudder_QueueConsumer {
     }
     $path = "/v1/batch";
     $url = $protocol . $dataPlaneUrl . $path;
-    $cmd = "curl -u ${secret}: -X POST -H 'Content-Type: application/json'";
+    $cmd = "curl -u {$secret}: -X POST -H 'Content-Type: application/json'";
 
     $tmpfname = "";
     $cmd.= " -d " . $payload;
@@ -63,7 +63,7 @@ class Rudder_Consumer_ForkCurl extends Rudder_QueueConsumer {
     $library = $messages[0]['context']['library'];
     $libName = $library['name'];
     $libVersion = $library['version'];
-    $cmd.= " -H 'User-Agent: ${libName}/${libVersion}'";
+    $cmd.= " -H 'User-Agent: {$libName}/{$libVersion}'";
 
     if (!$this->debug()) {
       $cmd .= " > /dev/null 2>&1 &";

--- a/lib/Rudder/Consumer/LibCurl.php
+++ b/lib/Rudder/Consumer/LibCurl.php
@@ -78,7 +78,7 @@ class Rudder_Consumer_LibCurl extends Rudder_QueueConsumer {
       $library = $messages[0]['context']['library'];
       $libName = $library['name'];
       $libVersion = $library['version'];
-      $header[] = "User-Agent: ${libName}/${libVersion}";
+      $header[] = "User-Agent: {$libName}/{$libVersion}";
 
       curl_setopt($ch, CURLOPT_HTTPHEADER, $header);
       curl_setopt($ch, CURLOPT_URL, $url);

--- a/lib/Rudder/Consumer/Socket.php
+++ b/lib/Rudder/Consumer/Socket.php
@@ -178,7 +178,7 @@ class Rudder_Consumer_Socket extends Rudder_QueueConsumer {
     $library = $content_json['batch'][0]['context']['library'];
     $libName = $library['name'];
     $libVersion = $library['version'];
-    $req.= "User-Agent: ${libName}/${libVersion}\r\n";
+    $req.= "User-Agent: {$libName}/{$libVersion}\r\n";
 
     // Compress content if compress_request is true
     if ($this->compress_request) {


### PR DESCRIPTION
## Description of the change

This pull request fix the deprecated string interpolation in PHP 8.2.

Reference: https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dollar-brace-interpolation

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
