### PR TITLE
Remove deprecated `${var}` in string

### DIFF
--- a/lib/Rudder.php
+++ b/lib/Rudder.php
@@ -160,7 +160,7 @@ private static function handleUrl($data_plane_url, $protocol) {
   public static function validate($msg, $type){
     $userId = !empty($msg["userId"]);
     $anonId = !empty($msg["anonymousId"]);
-    self::assert($userId || $anonId, "Rudder::${type}() requires userId or anonymousId");
+    self::assert($userId || $anonId, "Rudder::{$type}() requires userId or anonymousId");
   }
 
   /**


### PR DESCRIPTION
## Description of the change
Deprecated: Using ${var} in strings is deprecated, use {$var} instead
This deprecation message breaks our commit hook

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
