### PR TITLE
Move phpdotenv to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,6 @@
 	"require": {
 		"php": "^7.4 || ^8.0",
 		"ext-json": "*",
-		"vlucas/phpdotenv": "^5.5",
 		"ramsey/uuid": "^4.2.3"
 	},
 	"require-dev": {
@@ -30,7 +29,8 @@
 		"slevomat/coding-standard": "^8.7",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-		"donatj/mock-webserver": "^2.6"
+		"donatj/mock-webserver": "^2.6",
+		"vlucas/phpdotenv": "^5.5"
 	},
 	"suggest": {
 		"ext-curl": "For using the curl HTTP client",


### PR DESCRIPTION
## PR Description
Move the `vlucas/phpdotenv` to require-dev as it's only used in examples and tests.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
