### PR TITLE
chore: add DeepWiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # What is RudderStack?
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/rudderlabs/rudder-php-sdk)
+
 [RudderStack](https://rudderstack.com/) is a **customer data pipeline** tool for collecting, routing and processing data
 from your websites, apps, cloud tools, and data warehouse.
 


### PR DESCRIPTION
## Description

Add a DeepWiki badge to the README to provide quick access to the AI-generated documentation for this repository.

## Changes

- Added a [DeepWiki](https://deepwiki.com/rudderlabs/rudder-php-sdk) badge to `README.md`, placed below the main heading.

## Testing

- Verified the badge renders correctly in the Markdown preview.
- Confirmed the badge link points to the correct DeepWiki page for `rudderlabs/rudder-php-sdk`.
