### PR TITLE
fix: skip curl_close() on PHP 8.0+ where it has no effect

### DIFF
--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -93,8 +93,11 @@ class LibCurl extends QueueConsumer
 //            var_dump("\nResponse code: " . json_encode($responseCode));
 //            var_dump('===============================================');
 
-            //close connection
-            curl_close($ch);
+            // This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.
+            // @link https://www.php.net/manual/en/function.curl-close.php
+            if (PHP_VERSION_ID < 80000) {
+                curl_close($ch);
+            }
 
             if ($responseCode !== 200) {
                 // log error

--- a/lib/Consumer/LibCurl.php
+++ b/lib/Consumer/LibCurl.php
@@ -93,7 +93,8 @@ class LibCurl extends QueueConsumer
 //            var_dump("\nResponse code: " . json_encode($responseCode));
 //            var_dump('===============================================');
 
-            // This function has no effect. Prior to PHP 8.0.0, this function was used to close the resource.
+            // curl_close() has no effect on PHP 8.0+ when using CurlHandle objects.
+            // Keep this call only for PHP < 8.0, where it still closes the cURL resource handle.
             // @link https://www.php.net/manual/en/function.curl-close.php
             if (PHP_VERSION_ID < 80000) {
                 curl_close($ch);


### PR DESCRIPTION
## Summary
`curl_close()` has no effect since PHP 8.0 (handles are now CurlHandle objects auto-closed by GC) and is formally deprecated in PHP 8.5

Only call `curl_close()` on PHP < 8.0 where handles are still resources

[php.net/manual/en/function.curl-close.php](https://www.php.net/manual/en/function.curl-close.php)