### PR TITLE
chore(codeowners): set sdk_team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MoumitaM @bardisg
+* @rudderlabs/sdk_team

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: "BUG : <Title>"
 labels: bug, open source
-assignees: bardisg
+assignees: []
 ---
 
 **Describe the bug**


### PR DESCRIPTION
## PR Description

Replaces the individually-named code owners (`@MoumitaM @bardisg`) in `.github/CODEOWNERS` with the `@rudderlabs/sdk_team` team so any SDK team member's review can unblock chore PRs (Dependabot merges, CI fixes). Individually-named owners hard-block PRs whenever those people are unavailable. Also clears the hardcoded individual assignee from the bug-report issue template (`bardisg` → `[]`). Brings this repo in line with the other SDK repos already migrated.

## Notion ticket

[SDK-5175](https://linear.app/rudderstack/issue/SDK-5175/set-sdk-team-as-code-owners-in-rudder-php-sdk) (Linear)

## Checklist

Please add screenshots for any new features or UI bug fixes for the following browsers -

- Example passes for all 4 Consumers
  > Not applicable — config-only change (CODEOWNERS and issue template), no code touched.
- New code covered with unit tests
  > Not applicable — no code changes.

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
